### PR TITLE
fix: propagate evm version to AST compiler input

### DIFF
--- a/src/project_config/utils.rs
+++ b/src/project_config/utils.rs
@@ -24,6 +24,7 @@ impl ProjectConfigInput {
         let create_standard_json_for_ast = |sources: Sources, version: &Version| -> SolcInput {
             let mut settings = Settings::new(OutputSelection::ast_output_selection());
             settings.remappings = self.project_paths.remappings.clone();
+            settings.evm_version = Some(self.evm_version);
             settings.sanitize(version, SolcLanguage::Solidity);
             let root = utils::canonicalize(self.root.clone()).expect("root failed to canonicalize");
             let mut solc_input = SolcInput::new(SolcLanguage::Solidity, sources, settings);

--- a/test-configs/foundry-evm-version/foundry.toml
+++ b/test-configs/foundry-evm-version/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc = "0.8.34"
+evm_version = "osaka"

--- a/test-configs/foundry-evm-version/src/Counter.sol
+++ b/test-configs/foundry-evm-version/src/Counter.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.34;
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function leadingZeros(uint256 bitmap) public pure returns (uint256 leadingZeroCount) {
+        assembly {
+            leadingZeroCount := clz(bitmap)
+        }
+    }
+}

--- a/tests/ast_tests.rs
+++ b/tests/ast_tests.rs
@@ -50,6 +50,26 @@ mod foundry_symlink {
     }
 }
 
+mod foundry_evm_version {
+    use pretty_assertions::assert_eq;
+
+    use crate::common::ast_info;
+
+    const ROOT: &str = "test-configs/foundry-evm-version";
+
+    #[test]
+    fn ast_generation_uses_configured_evm_version() {
+        let ast_info = ast_info(ROOT).unwrap();
+        assert_eq!(ast_info.versioned_asts.len(), 1);
+        let ast_group = ast_info.versioned_asts.first().expect("no group found");
+        let sources = &ast_group.compiler_output.sources;
+        assert!(!sources.is_empty());
+        for ast_file in sources.values() {
+            assert!(ast_file.ast.as_ref().is_some_and(|s| !s.is_empty()));
+        }
+    }
+}
+
 mod hardhat_dupsource {
     use pretty_assertions::assert_eq;
 

--- a/tests/pre_ast_tests.rs
+++ b/tests/pre_ast_tests.rs
@@ -171,3 +171,23 @@ mod foundry_fix_version {
         assert_eq!(values.sources.len(), 1);
     }
 }
+
+#[allow(unused_imports)]
+mod foundry_evm_version {
+    use foundry_compilers::artifacts::EvmVersion;
+
+    use crate::common::get_compiler_input;
+
+    use super::{assert_eq, *};
+
+    const ROOT: &str = "test-configs/foundry-evm-version";
+
+    #[test]
+    fn compiler_input_respects_configured_evm_version() {
+        let c = get_compiler_input(ROOT).unwrap();
+        assert_eq!(c.len(), 1);
+
+        let values = c.values().next().expect("No files found");
+        assert_eq!(values.settings.evm_version, Some(EvmVersion::Osaka));
+    }
+}


### PR DESCRIPTION
## Summary

- propagate the configured Foundry/Hardhat `evm_version` into the solc settings used for AST generation
- add a Foundry Osaka regression fixture that uses the `clz` instruction
- cover both compiler input construction and full AST generation

## Motivation

Aderyn can read and display `evm_version = "osaka"` correctly, but AST generation currently builds a fresh `Settings` value and only copies remappings before calling solc. That means solc falls back to its default EVM version for the selected compiler.

For projects using solc `0.8.34` with Osaka-only instructions such as `clz`, this causes Aderyn to print `EVM version - osaka` and then fail compilation as if it were compiling for `prague`.

This fixes Cyfrin/aderyn#1082.

## Verification

- `cargo test foundry_evm_version`
- `cargo fmt --check`
- `git diff --check`

I also verified the downstream Aderyn repro manually:

- installed `aderyn 0.6.8` still fails on the provided repro with `The "clz" instruction is only available for Osaka-compatible VMs (you are currently compiling for "prague")`
- local Aderyn wired to this fixed crate scans the same repro successfully, ingesting 26 files with solc `0.8.34`
